### PR TITLE
removed vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ bower_components/
 css/
 js/
 node_modules/
-vendor/

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -6,10 +6,10 @@ module.exports = function (grunt) {
     require('load-grunt-tasks')(grunt); // Load all Grunt tasks that are listed in package.json automagically
 
     var JS_FILES = [
-      './vendor/js/snap.svg-min.js',
-      './vendor/js/reqwest.min.js',
-      './vendor/js/strftime-min.js',
-      './vendor/js/classie.js',
+      './bower_components/snap.svg/dist/snap.svg-min.js',
+      './bower_components/reqwest/reqwest.min.js',
+      './bower_components/strftime/strftime-min.js',
+      './bower_components/classie/classie.js',
       './assets/js/highlight.pack.js',
       './assets/js/switch.js',
       './assets/js/scrollMenu.js',
@@ -92,43 +92,14 @@ module.exports = function (grunt) {
             src: '_site/css/*.css'
           }
         },
-
-        copy: {
-          vendor: {
-            files: [{
-              expand: true,
-              cwd: "bower_components/classie/",
-              src: "classie.js",
-              dest: "vendor/js"
-            },
-            {
-              expand: true,
-              cwd: "bower_components/reqwest/",
-              src: "reqwest.min.js",
-              dest: "vendor/js"
-            },
-            {
-              expand: true,
-              cwd: "bower_components/snap.svg/dist/",
-              src: "snap.svg-min.js",
-              dest: "vendor/js"
-            },
-            {
-              expand: true,
-              cwd: "bower_components/strftime/",
-              src: "strftime-min.js",
-              dest: "vendor/js"
-            }]
-          }
-        },
-
+        
         concat: {
           options: {
-           separator: ';',
+           separator: ';'
           },
           development : {
             src: JS_FILES,
-            dest: 'js/cssclasses.js',
+            dest: 'js/cssclasses.js'
           }
         },
 
@@ -151,12 +122,11 @@ module.exports = function (grunt) {
     });
 
     // Register the grunt serve task
-    grunt.registerTask('serve', [ 'copy:vendor', 'concurrent:serve' ]);
+    grunt.registerTask('serve', ['concurrent:serve' ]);
 
     // Register the grunt build task
     grunt.registerTask('build', [
         'env:build',
-        'copy:vendor',
         'shell:jekyllBuild',
         'sass:build',
         'postcss',


### PR DESCRIPTION
I think, the `vendor` directory is not really neccessary since files are just copied there from different dependencies from `bower_components`. With this change, files are directly copied from the `bower_components` directory to the concatenated js file