### PR TITLE
Replace devdocs.io link - #42

### DIFF
--- a/_posts/2015-01-04-css-part1.markdown
+++ b/_posts/2015-01-04-css-part1.markdown
@@ -125,4 +125,4 @@ anotherselector {
 }
 {% endhighlight %}
 
-This is what we call shorthand. Some properties have a shorthand format that allows us to define more properties at once, but just in one line. The order and the way it works is not always very obvious so you might need to look it up on a <a href="http://devdocs.io/css/" target="_blank">reference</a>, but don't worry too much about it for now. It's just good that you know that it exists in case you see it. If you think it's confusing, just use the non shorthand format for your own code and specify each property at a time.
+This is what we call shorthand. Some properties have a shorthand format that allows us to define more properties at once, but just in one line. The order and the way it works is not always very obvious so you might need to look it up on a <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties" target="_blank">reference</a>, but don't worry too much about it for now. It's just good that you know that it exists in case you see it. If you think it's confusing, just use the non shorthand format for your own code and specify each property at a time.

--- a/_posts/2015-01-14-css-resources.markdown
+++ b/_posts/2015-01-14-css-resources.markdown
@@ -58,5 +58,5 @@ different sections and chapters so you can easily skip on topics you are already
 * <a href="http://www.w3.org/standards/techs/css#w3c_all" target="_blank">The official CSS3 *stuff*</a> - Unlike HTML5, CSS3 is not defined in one big specification. It consists of a lot of puzzle pieces called modules that each define a specific subset of CSS properties. Again, don’t be afraid to have a look at this at some point (it’s ok if that point is somewhere in the future), even if it seems overly technical at first.
 * <a href="https://developer.mozilla.org/en-US/docs/Web/CSS" target="_blank">Mozilla Developer Network CSS Portal</a>
 * <a href="http://caniuse.com/" target="_blank">caniuse</a> – Can I use provides up-to-date browser support tables for support of front-end web technologies on desktop and mobile web browsers.
-* <a href="http://devdocs.io/css" target="_blank">Search the CSS reference</a>
-* <a href="http://devdocs.io/html" target="_blank">Search the HTML reference</a>
+* <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference" target="_blank">Search the CSS reference</a>
+* <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element" target="_blank">Search the HTML reference</a>


### PR DESCRIPTION
This PR replaces the devdocs.io links mentioned in #42.