### PR TITLE
Replace Markdown parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '~> 3.1.6'
+gem 'jekyll', '~> 3.2.1'
 gem 'pygments.rb', '~> 0.6.3'
-gem 'redcarpet', '~> 3.3.4'
+gem 'kramdown', '~> 1.12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    colorator (0.1)
-    ffi (1.9.10)
-    jekyll (3.1.6)
-      colorator (~> 0.1)
+    colorator (1.1.0)
+    ffi (1.9.14)
+    forwardable-extended (2.6.0)
+    jekyll (3.2.1)
+      colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
       liquid (~> 3.0)
       mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
     jekyll-sass-converter (1.4.0)
       sass (~> 3.4)
-    jekyll-watch (1.4.0)
+    jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
-    kramdown (1.11.1)
+    kramdown (1.12.0)
     liquid (3.0.6)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
     posix-spawn (0.3.11)
     pygments.rb (0.6.3)
       posix-spawn (~> 0.3.6)
@@ -29,8 +33,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    redcarpet (3.3.4)
-    rouge (1.11.0)
+    rouge (1.11.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
     yajl-ruby (1.2.1)
@@ -39,9 +42,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 3.1.6)
+  jekyll (~> 3.2.1)
+  kramdown (~> 1.12.0)
   pygments.rb (~> 0.6.3)
-  redcarpet (~> 3.3.4)
 
 BUNDLED WITH
-   1.11.2
+   1.13.1

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ twitter_username: CSSclasses
 github_username:  CSSclasses
 
 # Build settings
-markdown: redcarpet
+markdown: kramdown
 highlighter: pygments
 permalink: pretty
 


### PR DESCRIPTION
Fixes #43.

It was caused by the current Markdown parser (redcarpet). Updated jekyll to the newest version and replace the old Markdown converter to [kramdown](https://rubygems.org/gems/kramdown) which is actively developed. 

Tested the changes locally and everything seems to be working fine. :)