### PR TITLE
Add back a missing JS file in dev env

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,6 @@ exclude:
   - "Gemfile"
   - "Gemfile.lock"
   - "gruntfile.js"
-  - "js/cssclasses.js"
   - "node_modules/"
   - "package.json"
   - "README.md"


### PR DESCRIPTION
Bug introduced in #48. It turned out adding the bundled JS file to the excludes list affects the development environment, so Jekyll ignored it when running the server locally.

The downside of reverting this change is the unminified bundled JS file will be copied and committed to the `gh-pages` branch, however it won't be served to the users (in the templates we use the minified version on production).