### PR TITLE
Remove unnecessary `type="text/css"` in examples

### DIFF
--- a/_posts/2015-01-04-css-part1.markdown
+++ b/_posts/2015-01-04-css-part1.markdown
@@ -37,7 +37,7 @@ To get you started, you can just insert a `style` tag inside of your `head tag:
 <head>
   <meta charset="UTF-8">
   <title>Our Page Title</title>
-  <style type="text/css">
+  <style>
     /* CSS styling rules here. Yes, comments are different in CSS. It’s not our fault! */
   </style>
 </head>
@@ -88,7 +88,7 @@ Now, let us insert a `div` and style it a little bit. So parts of your file shou
 {% highlight HTML %}
 <head>
 <!-- ... -->
-  <style type="text/css">
+  <style>
     div {
       color: white;
       background-color: green;

--- a/_posts/2015-01-05-css-font.markdown
+++ b/_posts/2015-01-05-css-font.markdown
@@ -55,7 +55,7 @@ Keep going with our example let’s add a font-family to the `div` we’ve creat
 {% highlight HTML %}
 <head>
 <!-- ... -->
-  <style type="text/css">
+  <style>
     div {
       color: white;
       background-color: green;
@@ -85,7 +85,7 @@ The `font-size` property allows you to set a font size for the text in your Elem
 {% highlight HTML %}
 <head>
 <!-- ... -->
-  <style type="text/css">
+  <style>
     html {
       font-size: 10px;
     }

--- a/_posts/2015-01-06-css-border.markdown
+++ b/_posts/2015-01-06-css-border.markdown
@@ -15,7 +15,7 @@ You can also put a nice `border` around your elements. Try this:
 {% highlight HTML %}
 <head>
 <!-- ... -->
-  <style type="text/css">
+  <style>
     div {
       color: white;
       background-color: green;

--- a/_posts/2015-01-09-css-class-selector.markdown
+++ b/_posts/2015-01-09-css-class-selector.markdown
@@ -15,7 +15,7 @@ Until now we used the element selector to apply styles to an element. What’s w
 {% highlight HTML %}
 <head>
 <!-- ... -->
-  <style type="text/css">
+  <style>
     div {
       color: white;
       background-color: green;
@@ -43,7 +43,7 @@ Copy this code example into your html file, and check out what it looks like in 
 {% highlight HTML %}
 <head>
 <!-- ... -->
-  <style type="text/css">
+  <style>
     div {
       width: 300px;
       height: 200px;

--- a/_posts/2015-01-10-css-transitions.markdown
+++ b/_posts/2015-01-10-css-transitions.markdown
@@ -15,7 +15,7 @@ Transitions are a nice way to add some interactive animations to your site. If y
 {% highlight HTML %}
 <head>
 <!-- ... -->
-  <style type="text/css">
+  <style>
     .changeonhover {
       color: white;
       background-color: green;


### PR DESCRIPTION
The `type`-attribute on style tags is not needed in HTML5.

This commit replaces `<style type="text/css">` with `<style>` in all examples to reduce boilerplate code.

This is in compliance with the [Google HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.xml):

> Specifying type attributes in these contexts is not necessary as HTML5 implies text/css and text/javascript as defaults. This can be safely done even for older browsers.

Source: https://google.github.io/styleguide/htmlcssguide.xml?showone=type_Attributes#type_Attributes

