### PR TITLE
Feat/75 improve theme switcher

### DIFF
--- a/_includes/switch.html
+++ b/_includes/switch.html
@@ -1,0 +1,14 @@
+{% comment %}Calculating uniquie ID for switch.{% endcomment %}
+{% capture switchID %}switch_{% increment switchCounter %}{% endcapture %}
+
+{% comment %}Defining default name value for inputs of switch. Can be overwritten by include{% endcomment %}
+{% capture nameValue %}{{include.name | default: switchID}}{% endcapture %}
+
+<div class="m-switch">
+  {% capture inputID %}{{switchID}}_{% increment inputCounter %}{% endcapture %}
+  <input class="m-switch__input" id="{{inputID}}" type="radio" name="{{nameValue}}" value="dark">
+  <label class="m-switch__label" for="{{inputID}}">Dark</label>
+  {% capture inputID %}{{switchID}}_{% increment inputCounter %}{% endcapture %}
+  <input class="m-switch__input" id="{{inputID}}" type="radio" name="{{nameValue}}" value="light" checked="checked">
+  <label class="m-switch__label" for="{{inputID}}">Light</label>
+</div>

--- a/_posts/2015-01-03-boilerplate.markdown
+++ b/_posts/2015-01-03-boilerplate.markdown
@@ -16,12 +16,8 @@ Elements are what makes up a HTML document. You can put elements inside of other
 
 A Tag is the thing that indicates an element’s purpose. For example, the `<p>` tag indicates a paragraph of text is in that element, and the `<li>` represents a ‘list item’. You’ll notice they’re always surrounded by angle brackets. Opening and Closing tags mark the beginning and end of an element and wrap its content, like so:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <p>This is a paragraph.</p>
 {% endhighlight %}
@@ -32,24 +28,16 @@ Always double-check that you’ve closed all your elements; otherwise, a browser
 
 Lastly, having elements inside of each other (“nesting”) looks just like this:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <p>This is a sentence, with an <em>em</em> element ("emphasize") inside of it.</p>
 {% endhighlight %}
 
 or this:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <div id="main-container">
   <h1>The h1 tag indicates the primary header of the document.</h1>
@@ -95,12 +83,8 @@ For now just keep in mind, that every box has some sort of display value.
 ### HTML Boilerplate
 There is some basic structure you don't need to spend too much time on that is always there. Let's handle this in a very quick walkthrough (code, line-by-line comments):
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <!DOCTYPE html>
 <!--This is a doctype. Every HTML file should have one.
@@ -124,12 +108,8 @@ for modern browsers but old browsers still pick up that your file is some kind o
 
 And there we are, this is our first valid HTML file! Here it is again, so you can neatly copy&paste it:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <!DOCTYPE html>
 <html>
@@ -152,12 +132,8 @@ Are you looking for a place to put your CSS? Don't rush, we will come to that. A
 
 There is a hierarchy of heading elements that you can use for headlines. They start with h1 and end with h6.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <h1>heading 1</h1>
 <h2>heading 2</h2>
@@ -170,12 +146,8 @@ There is a hierarchy of heading elements that you can use for headlines. They st
 #### Paragraph
 This is the perfect tag if you want to markup text. Even this text is wrapped in a p.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <p>Some text</p>
 {% endhighlight %}
@@ -184,12 +156,8 @@ This is the perfect tag if you want to markup text. Even this text is wrapped in
 These are some inline Elements that you can nest inside a paragraph. Strong and emphasis give some meaning to pieces of text, while break forces a
 linebreak.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <strong>Strong</strong> and <em>emphasis</em>,
 <br>break
@@ -198,12 +166,8 @@ linebreak.
 #### Images
 The image tag is special as it is self-closing, it has no closing tag (like the break tag). It also has a special attribute the src which carries the path to the actual image. The alt attribute is a placeholder, if for some reason the image does not load.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <img src="https://placehold.it/664x442" alt="placeholder image">
 {% endhighlight %}
@@ -212,12 +176,8 @@ The image tag is special as it is self-closing, it has no closing tag (like the 
 #### Links
 Links take the user to another page. The tag is simply an a which stands for anchor. It comes with the href (hyper reference) attribute, that tells the browser where to go to. You can also add a title attribute that shows once the user hovers over it.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <a href="http://cssconf.eu" title="CSSconf EU">CSSconfEU</a>
 {% endhighlight %}
@@ -225,12 +185,8 @@ Links take the user to another page. The tag is simply an a which stands for anc
 #### Div
 The div element is an element that does not have any special meaning or special styling. It’s perfect for grouping other elements together and assigning them a class or an id.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <div>I do nothing special</div>
 {% endhighlight %}

--- a/_posts/2015-01-04-css-part1.markdown
+++ b/_posts/2015-01-04-css-part1.markdown
@@ -28,12 +28,8 @@ CSS is used to style your HTML elements. You can manipulate the colors, margins,
 ### Start with inline styles
 To get you started, you can just insert a `style` tag inside of your `head tag:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <head>
   <meta charset="UTF-8">
@@ -47,12 +43,8 @@ To get you started, you can just insert a `style` tag inside of your `head tag:
 ### Basic CSS syntax
 CSS has a simple syntax. The file consists of a list of rules. Each rule consists of one or more selectors and a declaration block. Your selectors identify your HTML elements, so they are used to declare which part of the markup a style applies to. Let’s take the h1 title we wrote in our HTML file and give it a nice red color:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 h1 {
   color: red;
@@ -61,12 +53,8 @@ h1 {
 
 `h1` is the selector, the HTML element we want to style. `color` is one of the properties that we can give to our selector, and `red` is the value of this property. The right syntax is:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 selector {
   property: value; /* remember always to write a ; after your value. */
@@ -80,12 +68,8 @@ Refresh your browser (CMD + R) and see how the color of your title has changed. 
 
 Now, let us insert a `div` and style it a little bit. So parts of your file should look like this:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <head>
 <!-- ... -->
@@ -108,12 +92,8 @@ So now if you save and hit refresh, you should see a green block with some white
 ### Shorthand
 On some occasions you might see properties defined in different ways but doing the same thing, such as:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 selector {
   border-width: 1px;

--- a/_posts/2015-01-05-css-font.markdown
+++ b/_posts/2015-01-05-css-font.markdown
@@ -8,12 +8,8 @@ The `font-family` CSS property allows for a prioritized list of font family name
 
 You should always add at least one generic family in a font-family list, since there’s no guarantee that a specific font is installed on the computer or can be downloaded.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 body {
   font-family: Proxima-Nova, Helvetica, sans-serif;
@@ -24,12 +20,8 @@ Font family names must either be given quoted as strings, or unquoted as a seque
 
 Here a few examples how it’s done right:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 body {
   font-family: Times, "Times New Roman", Georgia, serif;
@@ -46,12 +38,8 @@ p {
 
 Keep going with our example let’s add a font-family to the `div` we’ve created before.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <head>
 <!-- ... -->
@@ -76,12 +64,8 @@ If you hit refresh (CMD + R) again, your font-family should have changed from th
 
 The `font-size` property allows you to set a font size for the text in your Element. There are different ways to set font-sizes that can get a little tricky, so let us only use the most simple technique for now (you should really revisit this topic later). We will assign fixed pixel values to our elements:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <head>
 <!-- ... -->

--- a/_posts/2015-01-06-css-border.markdown
+++ b/_posts/2015-01-06-css-border.markdown
@@ -6,12 +6,8 @@ title: "CSS Border Properties"
 ### Border
 You can also put a nice `border` around your elements. Try this:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <head>
 <!-- ... -->
@@ -33,12 +29,8 @@ You can also put a nice `border` around your elements. Try this:
 
 Now you assigned your `div` to have a `black` border that is `5px` thick and `solid`. Let’s `dissect the border property a little bit with a different border and a generic description:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 border: 20px dashed #ff88aa;
 border: <line-width> || <line-style> || <color>;

--- a/_posts/2015-01-08-css-hover.markdown
+++ b/_posts/2015-01-08-css-hover.markdown
@@ -6,12 +6,8 @@ title: "CSS Hover"
 ### Hover
 Hover is a small example of how you can add some fun little interactivity to your site. Take our `div` example from above and let’s add a little bit to our CSS:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 div {
   color: white;

--- a/_posts/2015-01-09-css-class-selector.markdown
+++ b/_posts/2015-01-09-css-class-selector.markdown
@@ -6,12 +6,8 @@ title: "CSS Class Selector"
 ### Class Selector
 Until now we used the element selector to apply styles to an element. What’s wrong with that? Nothing, until you want to have two or more differently styled `div`s on your page.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <head>
 <!-- ... -->
@@ -34,12 +30,8 @@ Until now we used the element selector to apply styles to an element. What’s w
 
 Copy this code example into your html file, and check out what it looks like in the browser. Now let’s say the second `div` should be blue. We can achieve that by assigning classes to the `divs in our HTML. We can then apply styles to each class in our CSS:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <head>
 <!-- ... -->

--- a/_posts/2015-01-10-css-cascade-inheritance.markdown
+++ b/_posts/2015-01-10-css-cascade-inheritance.markdown
@@ -29,12 +29,8 @@ Imagine you are styling a document with some paragraphs. All these paragraphs sh
 
 Here is one way to do this:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <head>
   <style>
@@ -99,12 +95,8 @@ When we talk about an HTML document, we often describe it as a family tree. When
 
 Consider the following document:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <html>
   <body>
@@ -138,12 +130,8 @@ For this document, the following statements are true:
 
 One way we can make use of these relationships in our CSS is through _inheritance_. Inheritance means that some CSS properties, like text color or font size, get passed down, or _inherited_ from parent to children and further descendants. So if we want all the text in our document to be green, instead of styling every single element we can add the following CSS:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 body {
   color: green;
@@ -154,12 +142,8 @@ All visible elements in an HTML document are descendants of the body element. Th
 
 Now let's make this document a bit more interesting:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <html>
   <head>
@@ -195,12 +179,8 @@ You will notice that the `a`-elements don't inherit the text color of their ance
 
 Unfortunately, blue on green is not very readable. It might be a good idea to change the link color for the `footer` by adding the following CSS:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 footer a {
   color: white;
@@ -230,12 +210,8 @@ Specificity means that a rule that is _more specific_ overpowers a rule that is 
 
 Some selectors are more specific by default. For example a _class selector_ will always have a higher specificity than an _element selector_. This makes sense, because selecting only elements with a certain class attribute is _more specific_ than selecting _every_ element of a type.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <html>
   <head>
@@ -263,12 +239,8 @@ The class selector `.danger-link` is even more specific, therefore it overwrites
 
 It is important to keep in mind that in the cascade _specificity beats the order_ of rules in your stylesheet. If a rule is followed by another rule with the _same specificity_, the second rule overwrites the first. If the first rule has a _higher specificity_, the first rule still overwrites any less specific rules that come after it.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <html>
   <head>

--- a/_posts/2015-01-11-css-more-selectors.markdown
+++ b/_posts/2015-01-11-css-more-selectors.markdown
@@ -15,12 +15,8 @@ The `:nth-of-type` works almost like the `:nth-child`. But `:nth-child` doesn't 
 
 The `~` sibling selector selects all elements that are *neighbors* of a selected element. So if you take the following example, simple rules can add dynamic behavior to your collection of fruits and vegetables:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 .vegetable-checkbox:checked ~ .vegetable { background-color: #aaf0bb; }
 

--- a/_posts/2015-01-12-css-transitions.markdown
+++ b/_posts/2015-01-12-css-transitions.markdown
@@ -6,12 +6,8 @@ title: "CSS Transitions"
 ### Transition
 Transitions are a nice way to add some interactive animations to your site. If you add a transition to an element, the browser will automatically animate between two states when they change. To try that you can combine what you just learned about classes and `:hover` and add the `transition` property to the mix:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight HTML %}
 <head>
 <!-- ... -->
@@ -46,24 +42,16 @@ data-embed-version="2" data-pen-title="CSSclasses :hover" class="codepen">See th
 
 Notice how we used a very complicated transition shorthand here:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 transition: 1s width 0.2s ease-out, 2s background-color, 0.5s height 0.5s;
 {% endhighlight %}
 
 Let’s break it down: `1s width 0.2s ease-out` are the values that define the transition just for the width. The shorthand syntax is:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 transition: transition-duration transition-property transition-delay transition-timing-function;
 {% endhighlight %}

--- a/_posts/2015-01-13-css-transform.markdown
+++ b/_posts/2015-01-13-css-transform.markdown
@@ -9,12 +9,8 @@ Transforms can be used to manipulate elements. You can take any element and add 
 
 Let’s go through these one by one. `translate` can be used in two different ways:
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 .movedownright {
   transform: translate(10px, 20px);
@@ -30,12 +26,8 @@ Both classes `.movedownright` and `.movedownright2` manipulate any element in th
 
 Using `skew` or `skewX` and `skewY` you can skew your elements by given angles on the x- or y-axis. With rotate you can `rotate` your elements by a given angle.
 
-<div class="m-switch">
-  <input class="m-switch__input" id="dark" type="radio" name="theme" onchange="darkenEverything()">
-  <label class="m-switch__label m-switch__label--is-dark" for="dark">Dark</label>
-  <input class="m-switch__input" id="light" type="radio" name="theme" checked="checked" onchange="lightenEverything()">
-  <label class="m-switch__label m-switch__label--is-light" for="light">Light</label>
-</div>
+{% include switch.html %}
+
 {% highlight CSS %}
 .skewme {
   transform: skew(20deg, 30deg);

--- a/_sass/modules/_m-code-block.scss
+++ b/_sass/modules/_m-code-block.scss
@@ -26,6 +26,7 @@ pre {
   padding: $base-unit;
   word-wrap: normal;
   white-space: pre;
+  transition: background-color .2s ease;
 }
 
 pre code { font-size: 1em; }

--- a/_sass/modules/_m-switch.scss
+++ b/_sass/modules/_m-switch.scss
@@ -1,74 +1,78 @@
+$switch__track-height: 28px;
+$switch__track-width: 60px;
+$switch__track-inner-spacing: 1px;
+$switch__track-outer-spacing: 1em;
+$switch__thumb-size: $switch__track-height - 2 * $switch__track-inner-spacing;
+$switch__thumb-way: ($switch__track-width - $switch__thumb-size - 2 * $switch__track-inner-spacing);
 
+$switch__thumb-color: $color-white;
+$switch__track-color: $color-persian-red;
+$switch__label-hl-color: $color-persian-red;
 
 .m-switch {
-  $switcher-height: 28px;
-  $switcher-width: 60px;
-  $switcher-inner-spacing: 1px;
-  $switcher-outer-spacing: 1em;
-  $thumb-size: $switcher-height - 2 * $switcher-inner-spacing;
-  $thumb-way: ($switcher-width - $thumb-size - 2 * $switcher-inner-spacing);
-
-  $thumb-color: $color-white;
-  $input-bg-color: $color-persian-red;
-  $label-hl-color: $color-persian-red;
+  @extend %sans-serif;
   
 	position: relative;
 	display: inline-flex;
-	margin: $switcher-outer-spacing 0;
+	margin: $switch__track-outer-spacing 0;
 	user-select: none;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
-	&__label {
-		z-index: 1;
-    line-height: $switcher-height;
-		cursor: pointer;
-		&:first-of-type {
-			padding-right: calc(#{$switcher-outer-spacing} + #{$switcher-width});
-		}
-		&:last-of-type {
-			margin-left: -$switcher-width;
-      padding-left: calc(#{$switcher-outer-spacing} + #{$switcher-width});
-      
-      &::before {
-        content: '';
-        position: absolute;
-        left: 50%;
-        display: inline-block;
-        width: $thumb-size;
-        height: $thumb-size;
-        margin-top: $switcher-inner-spacing;
-        vertical-align: top;
-        border-radius: 50%;
-        background-color: $thumb-color;
-        transform: translate3d(calc(-50% - #{$thumb-way / 2}), 0px, 0px);
-        transition: transform 0.15s ease-in;
-      }
-		}
-	}
-	&::after {
+
+  &::after {
     content: '';
     z-index: -1;
     position: absolute;
     left: 50%;
 		display: inline-block;
-		width: $switcher-width;
-		height: $switcher-height;
-		border-radius: $switcher-height / 2;
-		background-color: $input-bg-color;
+		width: $switch__track-width;
+		height: $switch__track-height;
+		border-radius: $switch__track-height / 2;
+		background-color: $switch__track-color;
     transform: translateX(-50%);
   }  
+}
 
-  &__input {
-    display: none;
-    &:checked {
-      + .m-switch__label {
-        z-index: 0;
-        color: $label-hl-color;
-      }
-      &:last-of-type ~ .m-switch__label::before {
-        transform: translate3d(calc(-50% + #{$thumb-way / 2}), 0px, 0px);
-      }
-    }
+.m-switch__label {
+  z-index: 1;
+  line-height: $switch__track-height;
+  cursor: pointer;
+}
+
+.m-switch__label:first-of-type {
+  padding-right: calc(#{$switch__track-outer-spacing} + #{$switch__track-width});
+}
+
+.m-switch__label:last-of-type {
+  margin-left: -$switch__track-width;
+  padding-left: calc(#{$switch__track-outer-spacing} + #{$switch__track-width});
+  
+  &::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    display: inline-block;
+    width: $switch__thumb-size;
+    height: $switch__thumb-size;
+    margin-top: $switch__track-inner-spacing;
+    vertical-align: top;
+    border-radius: 50%;
+    background-color: $switch__thumb-color;
+    transform: translate3d(calc(-50% - #{$switch__thumb-way / 2}), 0px, 0px);
+    transition: transform 0.15s ease-in;
   }
+}
+
+.m-switch__input {
+  display: none;
+}
+
+.m-switch__input:checked + .m-switch__label {
+  z-index: 0;
+  color: $switch__label-hl-color;
+}
+
+.m-switch__input:checked:last-of-type ~ .m-switch__label::before {
+  transform: translate3d(calc(-50% + #{$switch__thumb-way / 2}), 0px, 0px);
 }
 
 

--- a/_sass/modules/_m-switch.scss
+++ b/_sass/modules/_m-switch.scss
@@ -1,36 +1,75 @@
 
 
 .m-switch {
-  @extend %sans-serif;
+  $switcher-height: 28px;
+  $switcher-width: 60px;
+  $switcher-inner-spacing: 1px;
+  $switcher-outer-spacing: 1em;
+  $thumb-size: $switcher-height - 2 * $switcher-inner-spacing;
+  $thumb-way: ($switcher-width - $thumb-size - 2 * $switcher-inner-spacing);
 
-  margin-bottom: .5 * $base-unit;
-  text-transform: uppercase;
-}
-
-.m-switch__input { display: none; }
-
-.m-switch.is--light .m-switch__label--is-light:before { border: .25rem solid $color-persian-red; }
-
-.m-switch.is--dark .m-switch__label--is-dark:before {
-  border: .25rem solid $color-persian-red;
-  background-color: $color-mine-shaft;
-}
-
-.m-switch__label {
-  padding-left: 1.5 * $base-unit;
-  position: relative;
-  cursor: pointer;
-
-  &:not(:first-of-type) { margin-left: $base-unit; }
-
-  &::before {
-    border: .6rem solid $color-persian-red;
+  $thumb-color: $color-white;
+  $input-bg-color: $color-persian-red;
+  $label-hl-color: $color-persian-red;
+  
+	position: relative;
+	display: inline-flex;
+	margin: $switcher-outer-spacing 0;
+	user-select: none;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+	&__label {
+		z-index: 1;
+    line-height: $switcher-height;
+		cursor: pointer;
+		&:first-of-type {
+			padding-right: calc(#{$switcher-outer-spacing} + #{$switcher-width});
+		}
+		&:last-of-type {
+			margin-left: -$switcher-width;
+      padding-left: calc(#{$switcher-outer-spacing} + #{$switcher-width});
+      
+      &::before {
+        content: '';
+        position: absolute;
+        left: 50%;
+        display: inline-block;
+        width: $thumb-size;
+        height: $thumb-size;
+        margin-top: $switcher-inner-spacing;
+        vertical-align: top;
+        border-radius: 50%;
+        background-color: $thumb-color;
+        transform: translate3d(calc(-50% - #{$thumb-way / 2}), 0px, 0px);
+        transition: transform 0.15s ease-in;
+      }
+		}
+	}
+	&::after {
     content: '';
-    display: inline-block;
-    height: $base-unit;
-    left: 0;
+    z-index: -1;
     position: absolute;
-    top: .0625rem;
-    width: $base-unit;
+    left: 50%;
+		display: inline-block;
+		width: $switcher-width;
+		height: $switcher-height;
+		border-radius: $switcher-height / 2;
+		background-color: $input-bg-color;
+    transform: translateX(-50%);
+  }  
+
+  &__input {
+    display: none;
+    &:checked {
+      + .m-switch__label {
+        z-index: 0;
+        color: $label-hl-color;
+      }
+      &:last-of-type ~ .m-switch__label::before {
+        transform: translate3d(calc(-50% + #{$thumb-way / 2}), 0px, 0px);
+      }
+    }
   }
 }
+
+
+

--- a/assets/js/switch.js
+++ b/assets/js/switch.js
@@ -1,23 +1,31 @@
-(function(window) {
-  var highlightElements = document.getElementsByClassName('highlight');
+(function (window) {
+  var DARK = 'dark';
+  var LIGHT = 'light';
 
-  syntaxSwitchElements = document.getElementsByClassName('m-switch');
+  var highlightElements = [].slice.call(document.getElementsByClassName('highlight'));
+  var syntaxSwitchElements = [].slice.call(document.getElementsByClassName('m-switch'));
 
-  for (var i = 0; i < syntaxSwitchElements.length; ++i) {
-    syntaxSwitchElements[i].classList.add('highlight');
-    syntaxLight(syntaxSwitchElements[i]);
+  // Separating inputs from switch according to value for faster access
+  var switches = syntaxSwitchElements.map(function (item){
+    var inputs = item.querySelectorAll('input');
+
+    return {
+      node: item,
+      options: {
+        dark: inputs[0],
+        light: inputs[1]
+      }
+    }
+  });
+
+  function setSwitches(value) {
+    switches.forEach(function(item){
+      item.options[value].checked = true;
+    });
   }
 
-  window.lightenEverything = function lightenEverything() {
-    for (var i = 0; i < highlightElements.length; ++i) {
-      syntaxLight(highlightElements[i]);
-    }
-  }
-
-  window.darkenEverything = function darkenEverything() {
-    for (var i = 0; i < highlightElements.length; ++i) {
-      syntaxDark(highlightElements[i]);
-    }
+  function setThemes(themer) {
+    highlightElements.forEach(themer);
   }
 
   function syntaxLight(element) {
@@ -29,4 +37,18 @@
     element.classList.add('is--dark');
     element.classList.remove('is--light');
   }
+
+  function handleChange(e) {
+    var value = e.target.value;
+
+    if (value === DARK) {
+      setThemes(syntaxDark);
+      setSwitches(value);
+    } else if (value === LIGHT) {
+      setThemes(syntaxLight);
+      setSwitches(value);
+    }
+  }
+
+  window.addEventListener('change', handleChange);
 })(window);


### PR DESCRIPTION
This PR fixes #75 and improves the usability and behavior of the theme switch for code panes.
The refactoring includes:
- extracting of the switch markup as include
- fixing the existence of not unique ids for switch inputs (`dark`, `light` ) by adding a counter
- optimized  syncing of switches
- improved design of switch and improved highlight of active state

If theres something missing, just let me know :)