### PR TITLE
Changes names in package files to match allowed pattern

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-    "name": "CSSclasses",
+    "name": "cssclasses",
     "version": "1.0.0",
     "homepage": "https://github.com/CSSclasses/CSSclasses",
     "description": "The homepage for CSSclasses, a free CSS workshop series.",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "CSSclasses",
+    "name": "cssclasses",
     "description": "The homepage for CSSclasses, a free CSS workshop series.",
     "version": "1.0.0",
     "repository": {


### PR DESCRIPTION
While upgrading after #91, realized the package names should be lowercase. Not crucial, but a few curly lines less.